### PR TITLE
add files to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,10 @@
     "test": "node example.js",
     "generate-wordlist": "cat eff_large_wordlist.txt | cut -f2 | jq -sRc 'rtrimstr(\"\n\") | split(\"\n\")' > wordlist.json"
   },
+  "files": [
+    "index.js",
+    "wordlist.json"
+  ],
   "repository": {
     "type": "git",
     "url": "git+https://github.com/emilbayes/eff-diceware-passphrase.git"


### PR DESCRIPTION
Remove redundant packaging of the source wordlist, decreases package size from 190kB to 81kB