### PR TITLE
pin 2.0.4 of binary search to fix bug

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Generate a cryptographically random password from EFF's improved Diceware word list",
   "main": "index.js",
   "dependencies": {
-    "binary-search-bounds": "^2.0.4",
+    "binary-search-bounds": "2.0.4",
     "nanoassert": "^2.0.0",
     "secure-sample": "^2.0.0",
     "secure-shuffle": "^2.0.0"


### PR DESCRIPTION
Right now includes etc is broken because the binary search module introduced a bug in 2.0.5.
This fixes that by pinning to 2.0.4 for now.